### PR TITLE
Initialize variables before parsing command line

### DIFF
--- a/generator/Delphi/src/generator.dpr
+++ b/generator/Delphi/src/generator.dpr
@@ -102,7 +102,11 @@ var
   ParamOK: Boolean;
   SkipNext: Boolean;
 begin
+  // initialize values
   Result := false;
+  invalid := 0;
+  valid := 0;
+  ParamOK := false;
   // initialize the params list
   if not Assigned(FParams) then
     FParams := TStringList.Create(dupIgnore, false, false);


### PR DESCRIPTION
These variables can be undefined (or wrongly defined) when Windows "Controlled File Access" interferes with generator.exe creating an output file.  And then the program silently fails without any error messages. :(