### PR TITLE
optionally use CertUtil instead of PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ You can verify the generated `measurements.txt` with a `SHA256` utility:
 ```bash
 $ sha256sum ./data/measurements.txt
 ```
+**Windows (Command Line)**
+```
+C:>CertUtil -hashfile .\data\measurements.txt SHA256
+```
 **Windows (PowerShell)**
 ```powershell
 Get-FileHash .\data\measurements.txt -Algorithm SHA256


### PR DESCRIPTION
For generating a hash in Windows, you can use CertUtil if you don't want to use PowerShell