### PR TITLE
abouchez/mormot: noticeable performance boost

### DIFF
--- a/entries/abouchez/src/brcmormot.lpr
+++ b/entries/abouchez/src/brcmormot.lpr
@@ -534,7 +534,8 @@ begin
   assert(SizeOf(TBrcStation) = 64); // 64 bytes = CPU L1 cache line size
   // read command line parameters
   Executable.Command.ExeDescription := 'The mORMot One Billion Row Challenge';
-  fn := Executable.Command.ArgString(0, 'the data source #filename');
+  if Executable.Command.Arg(0, 'the data source #filename') then
+    Utf8ToFileName(Executable.Command.Args[0], fn);
   verbose := Executable.Command.Option(
     ['v', 'verbose'], 'generate verbose output with timing');
   affinity := Executable.Command.Option(


### PR DESCRIPTION
- in fact, the Station[] array was not 64-bytes aligned, so the L1 CPU cache access was suboptimal
- timing went from around 4.2s to 4.0s on my laptop (5% improvement)
- we could expect better scaling too with multiple threads on the Benchmark hardware, because L3 shared cache should be less polluted