### PR TITLE
abouchez / mormot: try SSE2 dedicated asm for ';' searching

### DIFF
--- a/entries/abouchez/README.md
+++ b/entries/abouchez/README.md
@@ -118,12 +118,12 @@ This is the expected behavior, and will be fine with the benchmark challenge, wh
 On my Intel 13h gen processor with E-cores and P-cores, forcing thread to core affinity does not make any huge difference (we are within the error margin):
 ```
 ab@dev:~/dev/github/1brc-ObjectPascal/bin$ ./abouchez measurements.txt -v
-Processing measurements.txt with 20 threads, chunkmb=4 and affinity=false
+Processing measurements.txt with 20 threads, 4MB chunks and affinity=0
 result hash=85614446, result length=1139418, stations count=41343, valid utf8=1
 done in 2.36s 6.6 GB/s
 
 ab@dev:~/dev/github/1brc-ObjectPascal/bin$ ./abouchez measurements.txt -v -a
-Processing measurements.txt with 20 threads, chunkmb=4 and affinity=true
+Processing measurements.txt with 20 threads, 4MB chunks and affinity=1
 result hash=85614446, result length=1139418, stations count=41343, valid utf8=1
 done in 2.44s 6.4 GB/s
 ```

--- a/entries/abouchez/src/brcmormot.lpr
+++ b/entries/abouchez/src/brcmormot.lpr
@@ -125,24 +125,24 @@ begin
   inherited Create({suspended=}false);
 end;
 
-{$ifdef FPC_CPUX64_actuallySLOWER:(}
+{$ifdef FPC_CPUX64}
 function NameLen(p: PUtf8Char): PtrInt; assembler; nostackframe;
 asm
-         lea      rdx, qword ptr [p + 2]
+         lea      rdx,  qword ptr [p + 2]
          movaps   xmm0, oword ptr [rip + @chr]
          movups   xmm1, oword ptr [rdx] // check first 16 bytes
          pcmpeqb  xmm1, xmm0
-         pmovmskb eax, xmm1
-         bsf      eax, eax
+         pmovmskb eax,  xmm1
+         bsf      eax,  eax
          jnz      @found
-@by16:   add      rdx, 16
+@by16:   add      rdx,  16
          movups   xmm1, oword ptr [rdx] // next 16 bytes
          pcmpeqb  xmm1, xmm0
-         pmovmskb eax, xmm1
-         bsf      eax, eax
+         pmovmskb eax,  xmm1
+         bsf      eax,  eax
          jz       @by16
-@found:  add      rax, rdx  // point to exact match
-         sub      rax, p    // return position
+@found:  add      rax,  rdx  // point to exact match
+         sub      rax,  p    // return position
          ret
          align    16
 @chr:    dq $3b3b3b3b3b3b3b3b


### PR DESCRIPTION
I have written some tuned SSE2 asm to search for the ';' char.

It does not seem to be a silver bullet on my Intel computer.
But I would like to test it on your AMD hardware, because it is difficult to guess if it may help.

At least, it was fun writing this small code, and may be educational.