### PR TITLE
hgrosser: input files must NOT longer have CR's

### DIFF
--- a/entries/hgrosser/README.md
+++ b/entries/hgrosser/README.md
@@ -3,17 +3,16 @@
 **1 billion row Challenge entry**
 
 ## Version
-Version 1.60
+Version 1.61
 
 ## How to compile
 The program was developed with FPC 3.2.2 and Lazarus 2.2.4
-
-There is a new Conditional "noCR" which is neccessary, if the input file has no CR's
 
 ## How to start
 ```
 Usage:   <path to input file> <bit-width for hash-list (16..28)>
 Example: hgrosser measurements.txt 16
+ - input file: must NOT have CR's (only LF's)
  - bit-width for hash-list: sets the size of the hash list, e.g. '16' => 65536 entries
 ```
 There are no switches like `-i` etc, only 2 values.
@@ -40,3 +39,4 @@ To speed things up:
 - Version 1.50: hash-list optimized, small improvements in parsing the file
 - Version 1.51: small improvements in asm function
 - Version 1.60: hash-list optimized, some minor improvements, Conditional "noCR" added
+- Version 1.61: Conditional "noCR" constantely enabled => input files must NOT have CR's

--- a/entries/hgrosser/src/1brc.pas
+++ b/entries/hgrosser/src/1brc.pas
@@ -4,7 +4,7 @@
 
 { $DEFINE XTEST}   {please keep this UNDEFINED / compile a safe or a fast program}
 { $DEFINE XINLINE} {please keep this UNDEFINED / use INLINE for routines or not}
-{ $DEFINE noCR}    {neccessary for input-files without CR's (only LF's)}
+{$DEFINE noCR}     {neccessary for input-files without CR's (only LF's)}
 
 {$IFDEF XTEST}
    {$R+} {$Q+} {$S+}                               {slow but safe}
@@ -21,7 +21,7 @@ uses
      sysutils, strutils, math;
 
 const
-  M_version = '1.60'; {version number}
+  M_version = '1.61'; {version number}
 
 {------------------------------ Common routines: ------------------------------}
 
@@ -520,10 +520,7 @@ begin
       begin
         Inc(p2, pred(p1)); {p2:=position of 'LF'}
                                    {get cityname and temperature, without CR: }
-        len := p2 - p1
-{$IFNDEF noCR}
-          - 1;
-{$ENDIF} {'-1' skips the CR}
+        len := p2 - p1 {$IFNDEF noCR} -1 {$ENDIF} ; {'-1' skips the CR}
         city[0] := chr(len);
         move(s[p1], city[1], len);
                                                         {extract temperature: }


### PR DESCRIPTION
Conditional "noCR" was enabled permanently, so that input file must NOT have CR's any longer